### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -26,3 +26,19 @@ p6df::modules::oci::external::brews() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words oci $OCI_CONFIG_FILE = p6df::modules::oci::profile::mod()
+#
+#  Returns:
+#	words - oci $OCI_CONFIG_FILE
+#
+#  Environment:	 OCI_CONFIG_FILE
+#>
+######################################################################
+p6df::modules::oci::profile::mod() {
+
+  p6_return_words 'oci' '$OCI_CONFIG_FILE'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -40,5 +40,5 @@ p6df::modules::oci::external::brews() {
 ######################################################################
 p6df::modules::oci::profile::mod() {
 
-  p6_return_words 'oci' '$OCI_CONFIG_FILE'
+  p6_return_words 'oci' "$"
 }


### PR DESCRIPTION
## What
Add `profile::mod` to p6df-oci using `p6_return_words` with word and variable as separate quoted arguments.

## Why
Consistent quoting convention for `p6_return_words` calls across all p6df modules.

## Test plan
- Verify `p6df::modules::oci::profile::mod` returns two words: `oci` and the value of `$OCI_CONFIG_FILE`
- Load module in zsh and confirm no errors

## Dependencies
None