### PR TITLE
fix(prompt): set OCI_CONFIG_FILE env var in profile::mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::oci::deps()`
 - `p6df::modules::oci::external::brew()`
+- `words oci $OCI_CONFIG_FILE = p6df::modules::oci::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -40,5 +40,5 @@ p6df::modules::oci::external::brews() {
 ######################################################################
 p6df::modules::oci::profile::mod() {
 
-  p6_return_words 'oci' "$"
+  p6_return_words 'oci' '$OCI_CONFIG_FILE'
 }


### PR DESCRIPTION
## What
Replace placeholder `"$"` with `'$OCI_CONFIG_FILE'` in `p6df::modules::oci::profile::mod()` and update README.

## Why
The prompt word list was missing the actual environment variable, causing the prompt to display nothing useful.

## Test plan
- Inspected change manually

## Dependencies
None