### PR TITLE
feat(oci): simplify profile::mod return value and rename brew to brews

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ TODO: Add a short summary of this module.
 ##### p6df-oci/init.zsh
 
 - `p6df::modules::oci::deps()`
-- `p6df::modules::oci::external::brew()`
-- `words oci $OCI_CONFIG_FILE = p6df::modules::oci::profile::mod()`
+- `p6df::modules::oci::external::brews()`
+- `words oci = p6df::modules::oci::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -30,10 +30,10 @@ p6df::modules::oci::external::brews() {
 ######################################################################
 #<
 #
-# Function: words oci $OCI_CONFIG_FILE = p6df::modules::oci::profile::mod()
+# Function: words oci = p6df::modules::oci::profile::mod()
 #
 #  Returns:
-#	words - oci $OCI_CONFIG_FILE
+#	words - oci
 #
 #  Environment:	 OCI_CONFIG_FILE
 #>


### PR DESCRIPTION
**What:** Simplify `profile::mod` return signature to `words oci` (removing `$OCI_CONFIG_FILE`) and rename `external::brew` to `external::brews`

**Why:** Reduces verbosity in the function return signature; consistent plural naming for brew installs

**Test plan:** Source the module and verify `p6df::modules::oci::profile::mod` still returns expected prompt context

**Dependencies:** none